### PR TITLE
update 2020.06.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ go(function () {
 | KuMEX\SDK\PublicApi\Symbol::getTicker() | NO | https://docs.kucoin.com/futures/#get-ticker |
 | KuMEX\SDK\PublicApi\Symbol::getLevel2Snapshot() | NO | https://docs.kucoin.com/futures/#get-full-order-book-level-2 |
 | KuMEX\SDK\PublicApi\Symbol::getLevel3Snapshot() | NO | https://docs.kucoin.com/futures/#get-full-order-book-level-3 |
+| KuMEX\SDK\PublicApi\Symbol::getV2Level3Snapshot() | NO | https://docs.kucoin.com/futures/#get-full-order-book-level-3-v2 |
 | KuMEX\SDK\PublicApi\Symbol::getLevel2Message() | NO | https://docs.kucoin.com/futures/##level-2-pulling-messages |
 | KuMEX\SDK\PublicApi\Symbol::getLevel3Message() | NO | https://docs.kucoin.com/futures/##level-3-pulling-messages |
 | KuMEX\SDK\PublicApi\Symbol::getTradeHistory() | NO | https://docs.kucoin.com/futures/#get-trade-histories |
@@ -283,6 +284,15 @@ go(function () {
 | API | Authentication | Description |
 | -------- | -------- | -------- |
 | KuMEX\SDK\PublicApi\Time::timestamp() | NO | https://docs.kucoin.com/futures/#server-time |
+
+</details>
+
+<details>
+<summary>KuMEX\SDK\PublicApi\Status</summary>
+
+| API | Authentication | Description |
+| -------- | -------- | -------- |
+| KuMEX\SDK\PublicApi\Status::status() | NO | https://docs.kucoin.com/futures/#get-the-service-status |
 
 </details>
 

--- a/examples/Status.php
+++ b/examples/Status.php
@@ -1,0 +1,12 @@
+<?php
+include '../vendor/autoload.php';
+
+use KuMEX\SDK\KuMEXApi;
+use KuMEX\SDK\PublicApi\Status;
+
+// Set the base uri, default "https://api.kumex.com" for production environment.
+// KuMEXApi::setBaseUri('https://api.kumex.com');
+
+$api = new Status();
+$status = $api->status();
+var_dump($status);

--- a/examples/WebSocketFeed.php
+++ b/examples/WebSocketFeed.php
@@ -23,10 +23,10 @@ $api = new WebSocketFeed($auth);
 //});
 //$api->setLoop($loop);
 
-$query = ['connectId' => uniqid('', true)];
+$query    = ['connectId' => uniqid('', true)];
 $channels = [
-    ['topic' => '/market/ticker:KCS-BTC'], // Subscribe multiple channels
-    ['topic' => '/market/ticker:ETH-BTC'],
+    ['topic' => '/contractMarket/ticker:XBTUSDM'], // Subscribe multiple channels
+    ['topic' => '/contractMarket/ticker:XBTUSDTM'],
 ];
 
 $api->subscribePublicChannels($query, $channels, function (array $message, WebSocket $ws, LoopInterface $loop) use ($api) {

--- a/src/Api.php
+++ b/src/Api.php
@@ -16,7 +16,12 @@ abstract class Api
     /**
      * @var string SDK Version
      */
-    const VERSION = '1.0.13';
+    const VERSION = '1.0.14';
+
+    /**
+     * @var string SDK update date
+     */
+    const UPDATE_DATE = '2020.06.18';
 
     /**
      * @var string

--- a/src/PublicApi/Status.php
+++ b/src/PublicApi/Status.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace KuMEX\SDK\PublicApi;
+
+use KuMEX\SDK\Http\Request;
+use KuMEX\SDK\KuMEXApi;
+
+/**
+ * Class Time
+ * @package KuMEX\SDK\PublicApi
+ * @see https://docs.kucoin.com/futures/#get-the-service-status
+ */
+class Status extends KuMEXApi
+{
+    /**
+     * Get the timestamp of Server in milliseconds
+     * @return array
+     * @throws \KuMEX\SDK\Exceptions\HttpException
+     * @throws \KuMEX\SDK\Exceptions\BusinessException
+     * @throws \KuMEX\SDK\Exceptions\InvalidApiUriException
+     */
+    public function status()
+    {
+        $response = $this->call(Request::METHOD_GET, '/api/v1/status');
+        return $response->getApiData();
+    }
+}

--- a/src/PublicApi/Symbol.php
+++ b/src/PublicApi/Symbol.php
@@ -58,6 +58,21 @@ class Symbol extends KuMEXApi
     }
 
     /**
+     * Get the snapshot details of a symbol.
+     *
+     * @param  string $symbol
+     * @return array
+     * @throws \KuMEX\SDK\Exceptions\BusinessException
+     * @throws \KuMEX\SDK\Exceptions\HttpException
+     * @throws \KuMEX\SDK\Exceptions\InvalidApiUriException
+     */
+    public function getV2Level3Snapshot($symbol)
+    {
+        $response = $this->call(Request::METHOD_GET, '/api/v2/level3/snapshot', compact('symbol'));
+        return $response->getApiData();
+    }
+
+    /**
      * Get the level2 message of a symbol.
      *
      * @param  string $symbol

--- a/tests/StatusTest.php
+++ b/tests/StatusTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace KuMEX\SDK\Tests;
+
+use KuMEX\SDK\PublicApi\Status;
+
+class StatusTest extends TestCase
+{
+    protected $apiClass    = Status::class;
+    protected $apiWithAuth = false;
+
+    /**
+     * @dataProvider apiProvider
+     * @param Status $api
+     * @throws \KuMEX\SDK\Exceptions\BusinessException
+     * @throws \KuMEX\SDK\Exceptions\HttpException
+     * @throws \KuMEX\SDK\Exceptions\InvalidApiUriException
+     */
+    public function testGetStatus(Status $api)
+    {
+        $status = $api->status();
+        $this->assertInternalType('array', $status);
+        $this->assertArrayHasKey('msg', $status);
+        $this->assertArrayHasKey('status', $status);
+    }
+}

--- a/tests/SymbolTest.php
+++ b/tests/SymbolTest.php
@@ -71,6 +71,24 @@ class SymbolTest extends TestCase
      * @throws \KuMEX\SDK\Exceptions\HttpException
      * @throws \KuMEX\SDK\Exceptions\InvalidApiUriException
      */
+    public function testGetV2Level3Snapshot(Symbol $api)
+    {
+        $data = $api->getV2Level3Snapshot('XBTUSDM');
+        $this->assertInternalType('array', $data);
+        $this->assertArrayHasKey('sequence', $data);
+        $this->assertArrayHasKey('symbol', $data);
+        $this->assertArrayHasKey('asks', $data);
+        $this->assertArrayHasKey('bids', $data);
+        $this->assertArrayHasKey('ts', $data);
+    }
+
+    /**
+     * @dataProvider apiProvider
+     * @param Symbol $api
+     * @throws \KuMEX\SDK\Exceptions\BusinessException
+     * @throws \KuMEX\SDK\Exceptions\HttpException
+     * @throws \KuMEX\SDK\Exceptions\InvalidApiUriException
+     */
     public function testGetLevel2Message(Symbol $api)
     {
         $data = $api->getLevel2Message('XBTUSDM', 1, 100);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,12 @@ use KuMEX\SDK\KuMEXApi;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-    protected $apiClass = 'Must be declared in the subclass';
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    protected $apiClass    = 'Must be declared in the subclass';
     protected $apiWithAuth = false;
 
     public function apiProvider()

--- a/tests/WebSocketFeedTest.php
+++ b/tests/WebSocketFeedTest.php
@@ -70,7 +70,7 @@ class WebSocketFeedTest extends TestCase
     public function testSubscribePublicChannel(WebSocketFeed $api)
     {
         $query = ['connectId' => uniqid('', true),];
-        $channel = ['topic' => '/market/ticker:XBTUSDM'];
+        $channel = ['topic' => '/contractMarket/ticker:XBTUSDM'];
 
         $options = [
 //            'tls' => [
@@ -80,6 +80,7 @@ class WebSocketFeedTest extends TestCase
         $api->subscribePublicChannel($query, $channel, function (array $message, WebSocket $ws, LoopInterface $loop) use ($api) {
             $this->assertInternalType('array', $message);
             $this->assertArrayHasKey('type', $message);
+            $this->assertArrayHasKey('channelType', $message);
             $this->assertEquals('message', $message['type']);
 
             // Dynamic output
@@ -101,8 +102,8 @@ class WebSocketFeedTest extends TestCase
     {
         $query = ['connectId' => uniqid('', true),];
         $channels = [
-            ['topic' => '/market/ticker:XBTUSDM'],
-            ['topic' => '/market/ticker:XBTUSDM'],
+            ['topic' => '/contractMarket/ticker:XBTUSDM'],
+            ['topic' => '/contractMarket/ticker:XBTUSDM'],
         ];
 
         $options = [
@@ -113,6 +114,7 @@ class WebSocketFeedTest extends TestCase
         $api->subscribePublicChannels($query, $channels, function (array $message, WebSocket $ws, LoopInterface $loop) use ($api) {
             $this->assertInternalType('array', $message);
             $this->assertArrayHasKey('type', $message);
+            $this->assertArrayHasKey('channelType', $message);
             $this->assertEquals('message', $message['type']);
 
             // Dynamic output
@@ -134,7 +136,7 @@ class WebSocketFeedTest extends TestCase
     public function testUnsubscribePublicChannel(WebSocketFeed $api)
     {
         $query = ['connectId' => uniqid('', true),];
-        $channel = ['topic' => '/market/ticker:XBTUSDM'];
+        $channel = ['topic' => '/contractMarket/ticker:XBTUSDM'];
 
         $options = [
 //            'tls' => [
@@ -144,6 +146,7 @@ class WebSocketFeedTest extends TestCase
         $api->subscribePublicChannel($query, $channel, function (array $message, WebSocket $ws, LoopInterface $loop) use ($api) {
             $this->assertInternalType('array', $message);
             $this->assertArrayHasKey('type', $message);
+            $this->assertArrayHasKey('channelType', $message);
             $this->assertEquals('message', $message['type']);
 
             // Dynamic output
@@ -164,7 +167,7 @@ class WebSocketFeedTest extends TestCase
     public function testSubscribePrivateChannel(WebSocketFeed $api)
     {
         $query = ['connectId' => uniqid('', true),];
-        $channel = ['topic' => '/market/match:XBTUSDM'];
+        $channel = ['topic' => '/contract/position:XBTUSDM'];
 
         $options = [
 //            'tls' => [
@@ -174,6 +177,7 @@ class WebSocketFeedTest extends TestCase
         $api->subscribePrivateChannel($query, $channel, function (array $message, WebSocket $ws, LoopInterface $loop) use ($api) {
             $this->assertInternalType('array', $message);
             $this->assertArrayHasKey('type', $message);
+            $this->assertArrayHasKey('channelType', $message);
             $this->assertEquals('message', $message['type']);
             // Dynamic output
             fputs(STDIN, print_r($message, true));
@@ -194,8 +198,8 @@ class WebSocketFeedTest extends TestCase
     {
         $query = ['connectId' => uniqid('', true),];
         $channels = [
-            ['topic' => '/market/match:XBTUSDM'],
-            ['topic' => '/market/match:XBTUSDM'],
+            ['topic' => '/contract/position:XBTUSDM'],
+            ['topic' => '/contract/position:XBTUSDM'],
         ];
 
         $options = [
@@ -206,6 +210,7 @@ class WebSocketFeedTest extends TestCase
         $api->subscribePrivateChannels($query, $channels, function (array $message, WebSocket $ws, LoopInterface $loop) use ($api) {
             $this->assertInternalType('array', $message);
             $this->assertArrayHasKey('type', $message);
+            $this->assertArrayHasKey('channelType', $message);
             $this->assertEquals('message', $message['type']);
             // Dynamic output
             fputs(STDIN, print_r($message, true));


### PR DESCRIPTION
新增获取服务状态接口，新增的接口： GET /api/v1/status
增加level3新版本全量数据获取接口:     GET /api/v2/level3/snapshot
修复test的websocket的topic